### PR TITLE
Pass `blob` to window.URL.createObjectURL

### DIFF
--- a/src/pages/orders/Orders.tsx
+++ b/src/pages/orders/Orders.tsx
@@ -40,7 +40,7 @@ const Orders = () => {
     const handleExport = async () => {
         const {data} = await axios.post('export', {}, {responseType: 'blob'});
         const blob = new Blob([data], {type: 'text/csv'});
-        const url = window.URL.createObjectURL(data);
+        const url = window.URL.createObjectURL(blob);
         const link = document.createElement('a');
         link.href = url;
         link.download = 'orders.csv';


### PR DESCRIPTION
The `blob` is currently not used  when the creating the object URL